### PR TITLE
Fix: Fixes Better-Sqlite3 Build Issues

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "workers-for-platforms-example-project",
   "version": "1.0.0",
   "license": "Apache-2.0",
+  "engines": {
+    "node": "<20"
+  },
   "devDependencies": {
     "@cloudflare/d1": "^1.4.1",
     "@cloudflare/workers-types": "^4.20240329.0",


### PR DESCRIPTION
Better-Sqlite3 v7.x doesn't support Node >= v20 and fails to build as a result. This PR locks down the required Node engine to versions prior to v20. More info on the upstream issue [here](https://github.com/WiseLibs/better-sqlite3/issues/1087#issuecomment-1763358915).